### PR TITLE
Improve "best asset" selection logic

### DIFF
--- a/src/components/AssetMetadata.vue
+++ b/src/components/AssetMetadata.vue
@@ -45,7 +45,7 @@ const isFavorite = computed(() => props.meta.isFavorite)
     <p>
       <span :class="{ best: best }"> {{ fileSize }} KB</span> from <code>{{ meta?.deviceId }}</code>
     </p>
-    <p>{{ resolution }} px</p>
+    <p>{{ resolution }} px<span v-if="meta.livePhotoVideoId">, <span class="best">live photo</span></span></p>
     <p v-if="meta?.type === 'VIDEO'">Length: {{ meta?.duration }}</p>
 
     <div v-if="albums?.length > 0">

--- a/src/components/AssetMetadata.vue
+++ b/src/components/AssetMetadata.vue
@@ -45,7 +45,7 @@ const isFavorite = computed(() => props.meta.isFavorite)
     <p>
       <span :class="{ best: best }"> {{ fileSize }} KB</span> from <code>{{ meta?.deviceId }}</code>
     </p>
-    <p>{{ resolution }} px<span v-if="meta.livePhotoVideoId">, <span class="best">live photo</span></span></p>
+    <p>{{ resolution }} px<span v-if="meta.livePhotoVideoId">, <span class="highlight">live photo</span></span></p>
     <p v-if="meta?.type === 'VIDEO'">Length: {{ meta?.duration }}</p>
 
     <div v-if="albums?.length > 0">


### PR DESCRIPTION
In this PR I added a very bare-bones logic to detect the best asset.

The asset will be selected, in order of priority, by analyzing live photo info, resolution, file extension (HEIC over JPG), and finally file size.

Additionally, the button to keep the best asset will not be enabled for videos of wildly varying durations (since they are unlikely to actually be duplicates).

Finally, live photos will clearly be labeled as such, to facilitate decision-making for the end users.